### PR TITLE
Add cycle modes and shuffle to music.py

### DIFF
--- a/plugins/antispam.py
+++ b/plugins/antispam.py
@@ -105,9 +105,9 @@ class AntiSpam(BasePlugin):
                     self.parent.logger.info(f"Muted member {self.member.display_name}")
                     self.muted = True
 
-        async def update(self):
+        async def update(self, parent):
             if self.needs_reinit:
-                return
+                self.reinit(parent)
             t_config = self.parent.plugin_config[str(self.guild.id)]
             if t_config["spam_role"] and time.time() - self.update_time > t_config['spam_role_timeout'] and self.muted:
                 for t_role in self.member.roles:
@@ -513,7 +513,7 @@ class AntiSpam(BasePlugin):
                 t_lst = []
                 for k1, t_member in t_guild.items():
                     if t_member.member and t_member.guild.get_member(t_member.member.id):
-                        t_future = asyncio.run_coroutine_threadsafe(t_member.update(), loop=loop)
+                        t_future = asyncio.run_coroutine_threadsafe(t_member.update(self), loop=loop)
                         try:
                             t_future.result()
                         except Exception as e:

--- a/plugins/antispam.py
+++ b/plugins/antispam.py
@@ -46,28 +46,19 @@ class AntiSpam(BasePlugin):
             self.guild = guild
             self.parent = parent
             self.infractions = 0
+            self.messages = 0
             self.update_time = time.time()
 
         def __getstate__(self):
-            copy = self.__dict__.copy()
-            result = {
-                'member': copy['member'].id,
-                'guild': copy['guild'].id,
-                'infractions': copy['infractions'],
-                'update_time': copy['update_time'],
-                'messages': copy['messages'],
-                'muted': copy['muted']
-            }
+            result = self.__dict__.copy()
+            del result["parent"]
+            result["member"] = result['member'].id
+            result["guild"] = result["guild"].id
+            result["needs_reinit"] = True
             return result
 
         def __setstate__(self, state):
-            self.member = state.get("member")
-            self.guild = state.get("guild")
-            self.infractions = state.get("infractions")
-            self.update_time = state.get("update_time")
-            self.messages = state.get("messages")
-            self.muted = state.get("muted", False)
-            self.needs_reinit = True
+            self.__dict__.update(state)
 
         def reinit(self, parent):
             self.parent = parent

--- a/plugins/logger.py
+++ b/plugins/logger.py
@@ -116,11 +116,11 @@ class DiscordLogger(BasePlugin):
             if before.roles != after.roles:
                 o_role = ", ".join([str(x) for x in before.roles])
                 n_role = ", ".join([str(x) for x in after.roles])
-                t_str = f"{t_str}**Old roles:**```{o_role.replace('@','')}```\n" \
-                        f"**New roles :**```{n_role.replace('@','')}```\n"
+                t_str = f"{t_str}**Old roles :**```[ {o_role.replace('@','')} ]```\n" \
+                        f"**New roles :**```[ {n_role.replace('@','')} ]```\n"
             if t_str == "":
                 return
-            self.logger.debug(f"User {uname} was modified:\n{t_str}")
+            self.logger.debug(f"User {uname} was modified:\n{t_str}".replace("```", " ").replace("**", ""))
             if gid not in self.log_items:
                 self.log_items[gid] = []
             self.log_items[gid].append(f"**WARNING. User {uname} was modified:**\n{t_str}")

--- a/plugins/music.py
+++ b/plugins/music.py
@@ -799,8 +799,8 @@ class MusicPlayer(BasePlugin):
             self.logger.warning("Unable to split {data.content}. {e}")
             raise SyntaxError(e)
         if len(args) > 1:
+            await respond(data, "**AFFIRMATIVE. Extending queue.**")
             with data.channel.typing():
-                await respond(data, "**AFFIRMATIVE. Extending queue.**")
                 t_i = None
                 if args[1].lower().startswith("index:"):
                     try:
@@ -859,7 +859,7 @@ class MusicPlayer(BasePlugin):
             raise PermissionError("You are banned from using the music module.")
         t_play = self.players[data.guild.id]
         if not t_play.check_perm(data):
-            raise PermissionError("You lack the required permissions.")
+            raise PermissionError
         if len(args) > 2:
             if args[1].lower() == "cycle":
                 if args[2].lower() == "none":
@@ -870,10 +870,7 @@ class MusicPlayer(BasePlugin):
                     t_play.cycle = 'one'
                 await respond(data, f"**AFFIRMATIVE. Current cycle mode: {t_play.cycle}.**", delete_after=5)
             elif args[1].lower() == "shuffle":
-                if args[2].lower() in ["off", "disable", "no", "negative"]:
-                    t_play.shuffle = False
-                elif args[2].lower() in ["on", "enable", "yes", "affirmative"]:
-                    t_play.shuffle = True
+                t_play.shuffle = self.is_positive(args[2].lower())
                 await respond(data, f"**AFFIRMATIVE. Shuffle {'enabled' if t_play.shuffle else 'disabled'}.**",
                               delete_after=5)
         else:
@@ -1055,6 +1052,15 @@ class MusicPlayer(BasePlugin):
         source.description = entry["description"]
         source.upload_date = entry["upload_date"]
         return source
+
+    @staticmethod
+    def is_positive(string):
+        if string in ["off", "disable", "no", "negative", "true"]:
+            return True
+        elif string in ["on", "enable", "yes", "affirmative", "false"]:
+            return False
+        else:
+            raise SyntaxError("Expected positive/negative input.")
 
     # Utility functions
 

--- a/plugins/music.py
+++ b/plugins/music.py
@@ -1,5 +1,5 @@
 from plugin_manager import BasePlugin
-from utils import Command, respond, split_message, find_user, DotDict
+from utils import Command, respond, split_message, find_user, DotDict, is_positive
 from youtube_dl.utils import DownloadError
 from discord import InvalidArgument, ClientException, FFmpegPCMAudio, PCMVolumeTransformer
 from plugins.channel_manager import ChannelNotFoundError
@@ -570,7 +570,7 @@ class MusicPlayer(BasePlugin):
             raise PermissionError("You are banned from using the music module.")
         t_play = self.players[data.guild.id]
         if not t_play.check_perm(data):
-            raise PermissionError("You lack the required permissions.")
+            raise PermissionError
         t_play.stop_song()
         if self.plugin_config["download_songs"]:
             args = data.content.split()
@@ -691,7 +691,7 @@ class MusicPlayer(BasePlugin):
             raise PermissionError("You are banned from using the music module.")
         t_play = self.players[data.guild.id]
         if not t_play.check_perm(data):
-            raise PermissionError("You lack the required permissions.")
+            raise PermissionError
         args = data.content.split(" ", 1)
         try:
             pos = int(args[1])
@@ -707,7 +707,7 @@ class MusicPlayer(BasePlugin):
     async def _musicban(self, data):
         t_play = self.players[data.guild.id]
         if not t_play.check_perm(data):
-            raise PermissionError("You lack the required permissions.")
+            raise PermissionError
         try:
             args = shlex.split(data.content)
         except ValueError as e:
@@ -737,7 +737,7 @@ class MusicPlayer(BasePlugin):
     async def _musicunban(self, data):
         t_play = self.players[data.guild.id]
         if not t_play.check_perm(data):
-            raise PermissionError("You lack the required permissions.")
+            raise PermissionError
         try:
             args = shlex.split(data.content)
         except ValueError as e:
@@ -769,7 +769,7 @@ class MusicPlayer(BasePlugin):
             raise PermissionError("You are banned from using the music module.")
         t_play = self.players[data.guild.id]
         if not t_play.check_perm(data):
-            raise PermissionError("You lack the required permissions.")
+            raise PermissionError
         t_string = ""
         if t_play.vc.source:
             t_string = f"\"{t_play.vc.source.url}\" "
@@ -792,7 +792,7 @@ class MusicPlayer(BasePlugin):
         t_play = self.players[data.guild.id]
         await t_play.connected(data)
         if not t_play.check_perm(data):
-            raise PermissionError("You lack the required permissions.")
+            raise PermissionError
         try:
             args = shlex.split(data.content)
         except ValueError as e:
@@ -870,7 +870,7 @@ class MusicPlayer(BasePlugin):
                     t_play.cycle = 'one'
                 await respond(data, f"**AFFIRMATIVE. Current cycle mode: {t_play.cycle}.**", delete_after=5)
             elif args[1].lower() == "shuffle":
-                t_play.shuffle = self.is_positive(args[2].lower())
+                t_play.shuffle = is_positive(args[2])
                 await respond(data, f"**AFFIRMATIVE. Shuffle {'enabled' if t_play.shuffle else 'disabled'}.**",
                               delete_after=5)
         else:
@@ -1052,15 +1052,6 @@ class MusicPlayer(BasePlugin):
         source.description = entry["description"]
         source.upload_date = entry["upload_date"]
         return source
-
-    @staticmethod
-    def is_positive(string):
-        if string in ["off", "disable", "no", "negative", "true"]:
-            return True
-        elif string in ["on", "enable", "yes", "affirmative", "false"]:
-            return False
-        else:
-            raise SyntaxError("Expected positive/negative input.")
 
     # Utility functions
 

--- a/plugins/music.py
+++ b/plugins/music.py
@@ -831,7 +831,7 @@ class MusicPlayer(BasePlugin):
         if self.check_ban(data):
             raise PermissionError("You are banned from using the music module.")
         t_play = self.players[data.guild.id]
-        if not t_play.vc.source or (not t_play.vc.is_playing() and not t_play.vc.is_paused()):
+        if not t_play.vc.source or (t_play.vc.source and not t_play.vc.is_playing() and not t_play.vc.is_paused()):
             await t_play.disconnect()
             await respond(data, "**AFFIRMATIVE. Leaving voice chat.**")
         elif t_play.check_perm(data):

--- a/plugins/music.py
+++ b/plugins/music.py
@@ -547,11 +547,11 @@ class MusicPlayer(BasePlugin):
             try:
                 vol = int(args[1])
             except ValueError:
-                raise SyntaxError("Expected integer value between 0 and 200!")
+                raise SyntaxError("Expected integer value between 0 and 100!")
             if vol < 0:
                 vol = 0
-            if vol > 200:
-                raise SyntaxError("Expected integer value between 0 and 200!")
+            if vol > 100:
+                raise SyntaxError("Expected integer value between 0 and 100!")
             if vol != t_play.volume:
                 await respond(data, f"**AFFIRMATIVE. Adjusting volume: {t_play.volume}% to {vol}%.**", delete_after=5)
                 t_play.set_volume(vol)

--- a/utils.py
+++ b/utils.py
@@ -248,6 +248,21 @@ def p_time(seconds):
     return ", ".join(t_string)
 
 
+def is_positive(string):
+    """
+    Returns True if the string is a positive word and False if the string is a negative word
+    :type string: str
+    :param string: string to be judged
+    :return: boolean
+    """
+    if string.lower() in ["off", "disable", "no", "negative", "true"]:
+        return True
+    elif string.lower() in ["on", "enable", "yes", "affirmative", "false"]:
+        return False
+    else:
+        raise SyntaxError("Expected positive/negative input.")
+
+
 class Command:
     """
     Defines a decorator that encapsulates a chat command. Provides a common


### PR DESCRIPTION
* ServerStorage now has "cycle" and "shuffle" attributes, str and bool
* .add_song now accepts an optional index keyword argument
* made the after functions print out error messages
* play_next will re-add songs based on cycle setting.
* skipping song while in 'all' re-adds it, in 'one' deletes it
* volume command now uses delcall and delete_after
* added togglevc command for toggling cycle/shuffle
* togglevc requires mute_members and uses delcall
* appendqueue can now take index:int as first argument to append at