### PR TITLE
Implement argparse into Purge and Role commands.

### DIFF
--- a/plugins/admin_commands.py
+++ b/plugins/admin_commands.py
@@ -69,7 +69,7 @@ class AdminCommands(BasePlugin):
                                                  log_type="purge_event")
             for d in deleted[::-1]:
                 await self.plugin_manager.hook_event("on_log_event", msg.guild,
-                                                     f"{d.author}({d.author.id}):\n{d.content}",
+                                                     f"{d.author}({d.author.id}) @ {d.created_at}:\n{d.content}",
                                                      log_type="purge_event")
             await self.plugin_manager.hook_event("on_log_event", msg.guild,
                                                  "**Verbose purge dump complete.**",

--- a/plugins/admin_commands.py
+++ b/plugins/admin_commands.py
@@ -2,7 +2,7 @@ import re
 from asyncio import sleep
 from plugin_manager import BasePlugin
 from rs_errors import CommandSyntaxError
-from rs_utils import respond, find_user
+from rs_utils import respond, find_user, RSArgumentParser
 from command_dispatcher import Command
 import shlex
 
@@ -10,62 +10,81 @@ import shlex
 class AdminCommands(BasePlugin):
     name = "admin_commands"
 
-    @Command("Purge", "Prune", "RPurge", "RPrune",
-             doc="Purges messages from the channel in bulk.\nUse R- variant for regexp match filtering.\nWARNING: "
+    @Command("Purge", "Prune",
+             doc="Purges messages from the channel in bulk.\nUse -r option for regexp match filtering.\nWARNING: "
                  "some special characters such as \"\\\" may need to be escaped - eg, use \"\\\\\" or wrap match "
                  "into quotation marks instead.",
-             syntax="(count) [match] [user mention/user id/user name]",
-             category="admin",
+             syntax="(count) [match] [-u/--user mention/ID/Name] [-r/--regex] [-v/--verbose] [-e/--emulate/--dryrun]",
              run_anywhere=True,
-             perms={"manage_messages"})
-    async def _purge(self, msg):
-        args = shlex.split(msg.content)
-        try:
-            count = int(args[1])
-            if count > 250:
-                count = 250
-            elif count < 0:
-                raise ValueError
-        except IndexError:
-            raise CommandSyntaxError("No count to delete provided.")
-        except ValueError:
-            raise CommandSyntaxError("Count to delete is not a valid number.")
-        if len(args) > 2:
-            searchstr = args[2]
-        else:
-            searchstr = None
+             perms={"manage_messages"},
+             category="admin")
+    async def _tpurge(self, msg):
+
+        parser = RSArgumentParser(add_help=False)
+        parser.add_argument("command")
+        parser.add_argument("count", type=int)
+        parser.add_argument("match", default=False, nargs='*')
+        parser.add_argument("-r", "--regex", action="store_true")
+        parser.add_argument("-u", "--user", action="append")
+        parser.add_argument("-v", "--verbose", action="store_true")
+        parser.add_argument("-e", "--emulate", "--dryrun", action="store_true")
+
+        args = parser.parse_args(shlex.split(msg.content))
+
+        # Clamp the count. No negatives (duh), not more than 250 (don't get trigger happy)
+        args['count'] = min(max(args['count'], 0), 250)
+
+        if args['match']:
+            args['match'] = ' '.join(args['match'])
+
+        # find all possible members mentioned
         members = []
-        if len(args) > 3:
-            for s in args[3:]:
-                members.append(find_user(msg.guild, s))
+        if args['user']:
+            for q in args['user']:
+                u = find_user(msg.guild, q)
+                if u:
+                    members.append(u.id)
+
         await msg.delete()
-        # check if regexp version is used
-        args[0] = args[0].lower().endswith('rpurge') or args[0].lower().endswith('rprune')
-        deleted = await msg.channel.purge(limit=count,
-                                          check=((lambda x: self.rsearch(x, searchstr, members)) if
-                                                 args[0] else (lambda x: self.search(x, searchstr, members))))
-        fb = await respond(msg, f"**PURGE COMPLETE: {len(deleted)} messages purged.**")
+
+        if not args['emulate']:
+            # actual purging
+            deleted = await msg.channel.purge(limit=args['count'],
+                                              check=((lambda x: self.rsearch(x, args['match'], members)) if
+                                                     args['regex'] else
+                                                     (lambda x: self.search(x, args['match'], members))))
+        else:
+            # dry run to test your query
+            deleted = []
+            check = ((lambda x: self.rsearch(x, args['match'], members)) if args['regex'] else
+                     (lambda x: self.search(x, args['match'], members)))
+            async for m in msg.channel.history(limit=args['count']):
+                if check(m):
+                    deleted.append(m)
+
+        # if you REALLY want those messages
+        if args['verbose']:
+            await self.plugin_manager.hook_event("on_log_event", msg.guild,
+                                                 "**WARNING: Beginning verbose purge dump.**",
+                                                 log_type="purge_event")
+            for d in deleted[::-1]:
+                await self.plugin_manager.hook_event("on_log_event", msg.guild,
+                                                     d.content, log_type="purge_event")
+            await self.plugin_manager.hook_event("on_log_event", msg.guild,
+                                                 "**Verbose purge dump complete.**",
+                                                 log_type="purge_event")
+
+        fb = await respond(msg, f"**PURGE COMPLETE: {len(deleted)} messages purged.**" +
+                           (f"\n**Purge query: **{args['match']}" if args['match'] else ""))
         await sleep(5)
         await fb.delete()
 
     @staticmethod
-    def search(msg, searchstr, members=None):
-        if searchstr:
-            t_find = searchstr.lower() in msg.content.lower()
-            if members:
-                return t_find and msg.author in members
-            else:
-                return t_find
-        else:
-            return True
+    def search(msg, searchstr, members=list()):
+        return ((not searchstr) or (searchstr.lower() in msg.content.lower())) and \
+               ((msg.author.id in members) or not members)
 
     @staticmethod
-    def rsearch(msg, searchstr, members=None):
-        if searchstr:
-            t_find = re.match(searchstr.lower(), msg.content.lower())
-            if members:
-                return t_find and msg.author in members
-            else:
-                return t_find
-        else:
-            return True
+    def rsearch(msg, searchstr, members=list()):
+        return ((not searchstr) or re.match(searchstr.lower(), msg.content.lower())) and \
+               ((msg.author.id in members) or not members)

--- a/plugins/admin_commands.py
+++ b/plugins/admin_commands.py
@@ -69,7 +69,8 @@ class AdminCommands(BasePlugin):
                                                  log_type="purge_event")
             for d in deleted[::-1]:
                 await self.plugin_manager.hook_event("on_log_event", msg.guild,
-                                                     d.content, log_type="purge_event")
+                                                     f"{d.author}({d.author.id}):\n{d.content}",
+                                                     log_type="purge_event")
             await self.plugin_manager.hook_event("on_log_event", msg.guild,
                                                  "**Verbose purge dump complete.**",
                                                  log_type="purge_event")

--- a/plugins/roles.py
+++ b/plugins/roles.py
@@ -1,11 +1,11 @@
 from discord import InvalidArgument, HTTPException, Forbidden, Colour
 from plugin_manager import BasePlugin
 from rs_errors import CommandSyntaxError
-from rs_utils import respond, is_positive, find_role, split_output
+from rs_utils import respond, is_positive, find_role, split_output, RSArgumentParser
 from command_dispatcher import Command
 from string import capwords
 import shlex
-import argparse
+from argparse import SUPPRESS
 
 
 class RoleCommands(BasePlugin):
@@ -35,7 +35,7 @@ class RoleCommands(BasePlugin):
             self.logger.warning(f"Unable to split {msg.content}. {e}")
             raise CommandSyntaxError(e)
 
-        parser = argparse.ArgumentParser(add_help=False, argument_default=argparse.SUPPRESS)
+        parser = RSArgumentParser(argument_default=SUPPRESS)
         parser.add_argument("command")                      # Well it's gonna be there.
         parser.add_argument("role")                         # The role name/ID
         parser.add_argument("-n", "--name")                 # New role name
@@ -44,10 +44,8 @@ class RoleCommands(BasePlugin):
         parser.add_argument("-m", "--mentionable")          # To allow role being mentioned
         parser.add_argument("-p", "--position", type=int)   # Changing position (DON'T ACTUALLY USE IT)
         if len(args) > 1:
-            try:
-                p_args = parser.parse_args(args).__dict__
-            except:
-                raise CommandSyntaxError("Invalid arg string.")
+            p_args = parser.parse_args(args)
+
             role = find_role(msg.guild, p_args['role'])
             if role:
                 # strip out irrelevant fields
@@ -94,7 +92,7 @@ class RoleCommands(BasePlugin):
             self.logger.warning(f"Unable to split {msg.content}. {e}")
             raise CommandSyntaxError(e)
 
-        parser = argparse.ArgumentParser(add_help=False)
+        parser = RSArgumentParser()
         parser.add_argument("command")                      # Well it's gonna be there.
         parser.add_argument("role")                         # Name of the new role
         parser.add_argument("template")                     # Permission donor name/ID
@@ -105,10 +103,7 @@ class RoleCommands(BasePlugin):
         parser.add_argument("-p", "--position", type=int)   # Changing position (DON'T ACTUALLY USE IT)
 
         if len(args) > 2:
-            try:
-                p_args = parser.parse_args(args).__dict__
-            except:
-                raise CommandSyntaxError("Invalid arg string.")
+            p_args = parser.parse_args(args)
             role = find_role(msg.guild, p_args['template'])
             if role:
                 try:

--- a/plugins/roles.py
+++ b/plugins/roles.py
@@ -5,6 +5,7 @@ from rs_utils import respond, is_positive, find_role, split_output
 from command_dispatcher import Command
 from string import capwords
 import shlex
+import argparse
 
 
 class RoleCommands(BasePlugin):
@@ -13,11 +14,12 @@ class RoleCommands(BasePlugin):
     @Command("EditRole",
              perms={"manage_roles"},
              category="roles",
-             syntax="(role) [name=string][colour=FFFFFF][hoist=bool][mentionable=bool][position=integer].\n"
+             syntax="(role) [-n/--name string][-c/--colour FFFFFF][-h/--hoist bool][-m/--mentionable bool][-p/"
+                    "--position integer].\n"
                     "ANALYSIS: Strings can be encapsulated in \"...\" to allow spaces",
              doc="Edits the specified role name, colour, hoist (show separately from others)"
                  " and mentionable properties.\n"
-                 "WARNING: Options must be specified as option=value. No spaces around `=`.\n"
+                 "WARNING: Options must be specified as \"--option value\" or \"-o value\".\n"
                  "ANALYSIS: Colour can be reset by setting it to 0.")
     async def _editrole(self, msg):
         """
@@ -32,47 +34,52 @@ class RoleCommands(BasePlugin):
         except ValueError as e:
             self.logger.warning(f"Unable to split {msg.content}. {e}")
             raise CommandSyntaxError(e)
+
+        parser = argparse.ArgumentParser(add_help=False, argument_default=argparse.SUPPRESS)
+        parser.add_argument("command")                      # Well it's gonna be there.
+        parser.add_argument("role")                         # The role name/ID
+        parser.add_argument("-n", "--name")                 # New role name
+        parser.add_argument("-c", "--colour", "--color")    # New role colour
+        parser.add_argument("-h", "--hoist")                # To separate the role or not
+        parser.add_argument("-m", "--mentionable")          # To allow role being mentioned
+        parser.add_argument("-p", "--position", type=int)   # Changing position (DON'T ACTUALLY USE IT)
         if len(args) > 1:
-            role = find_role(msg.guild, args[1])
+            try:
+                p_args = parser.parse_args(args).__dict__
+            except:
+                raise CommandSyntaxError("Invalid arg string.")
+            role = find_role(msg.guild, p_args['role'])
             if role:
-                t_dict = {}
-                for arg in args[2:]:
-                    t_arg = arg.split("=")
-                    if len(t_arg) > 1:  # beautiful
-                        if t_arg[0].lower() == "name":
-                            t_dict["name"] = t_arg[1]
-                        elif t_arg[0].lower() == "colour":
-                            t_dict["colour"] = Colour(int(t_arg[1], 16))
-                        elif t_arg[0].lower() == "color":
-                            t_dict["colour"] = Colour(int(t_arg[1], 16))
-                        elif t_arg[0].lower() == "hoist":
-                            t_dict["hoist"] = is_positive(t_arg[1])
-                        elif t_arg[0].lower() == "mentionable":
-                            t_dict["mentionable"] = is_positive(t_arg[1])
-                        elif t_arg[0].lower() == "position":
-                            if t_arg[1].isdecimal():
-                                pos = int(t_arg[1])
-                                if pos >= 0:
-                                    t_dict["position"] = pos
-                            else:
-                                raise CommandSyntaxError("Position must be a positive integer.")
-                if len(t_dict) == 0:  # you're wasting my time
+                # strip out irrelevant fields
+                t_dict = {k: v for k, v in p_args.items() if v and k not in ["command", "role"]}
+                # colour has to be a Colour()
+                if "colour" in t_dict:
+                    try:
+                        t_dict["colour"] = Colour(int(t_dict["colour"], 16))
+                    except ValueError:
+                        raise CommandSyntaxError("Colour must be in web-colour hexadecimal format.")
+                # position can't be below 0. Or over max number of roles but shhh
+                if "position" in t_dict:
+                    t_dict["position"] = max(0, t_dict["position"])
+                if "mentionable" in t_dict:
+                    t_dict["mentionable"] = is_positive(t_dict["mentionable"])
+                if "hoist" in t_dict:
+                    t_dict["hoist"] = is_positive(t_dict["hoist"])
+                if len(t_dict) == 0:
                     raise CommandSyntaxError
-                await role.edit(**t_dict)
-                t_string = ""
-                for k, v in t_dict.items():
-                    t_string = f"{t_string}{k}: {v!s}\n"
-                name = args[1].capitalize()
-                await respond(msg, f"**AFFIRMATIVE. Role {name} modified with parameters :**\n ```{t_string}```")
+                t_string = "\n".join([f"{k}: {v!s}" for k, v in t_dict.items()])
+                await respond(msg, f"**AFFIRMATIVE. Role {p_args['role'].capitalize()} modified with parameters :**\n "
+                                   f"```{t_string}```")
             else:
-                await respond(msg, f"**NEGATIVE. ANALYSIS: no role {args[1].capitalize()} found.**")
+                raise CommandSyntaxError(f"No role \"{p_args['role']}\" found.")
         else:
             raise CommandSyntaxError
 
     @Command("CreateRole",
              perms={"manage_roles"},
              category="roles",
-             syntax="(role name) (base role) [name=string][colour=FFFFFF][hoist=bool][mentionable=bool].\n"
+             syntax="(role name) (base role) [-n/--name string][-c/--colour FFFFFF][-h/--hoist bool]"
+                    "[-m/--mentionable bool][-p/--position integer].\n"
                     "ANALYSIS: Strings can be encapsulated in \"...\" to allow spaces",
              doc="Creates a role based on an existing role (for position and permissions), "
              "with parameters similar to editrole")
@@ -86,39 +93,39 @@ class RoleCommands(BasePlugin):
         except ValueError as e:
             self.logger.warning(f"Unable to split {msg.content}. {e}")
             raise CommandSyntaxError(e)
+
+        parser = argparse.ArgumentParser(add_help=False)
+        parser.add_argument("command")                      # Well it's gonna be there.
+        parser.add_argument("role")                         # Name of the new role
+        parser.add_argument("template")                     # Permission donor name/ID
+        parser.add_argument("-n", "--name")                 # New role name
+        parser.add_argument("-c", "--colour", "--color")    # New role colour
+        parser.add_argument("-h", "--hoist")                # To separate the role or not
+        parser.add_argument("-m", "--mentionable")          # To allow role being mentioned
+        parser.add_argument("-p", "--position", type=int)   # Changing position (DON'T ACTUALLY USE IT)
+
         if len(args) > 2:
-            role = find_role(msg.guild, args[2])
+            try:
+                p_args = parser.parse_args(args).__dict__
+            except:
+                raise CommandSyntaxError("Invalid arg string.")
+            role = find_role(msg.guild, p_args['template'])
             if role:
-                # copying the existing role (especially permissions)
-                t_dict = {
-                    "name": args[1],
-                    "permissions": role.permissions,
-                    "colour": role.colour,
-                    "hoist": role.hoist,
-                    "mentionable": role.mentionable
-                }
-                rolepos = role.position
-                for arg in args[3:]:
-                    t_arg = arg.split("=")
-                    if len(t_arg) > 1:  # beautiful
-                        if t_arg[0].lower() == "name":
-                            t_dict["name"] = t_arg[1]
-                        elif t_arg[0].lower() == "colour":
-                            t_dict["colour"] = Colour(int(t_arg[1], 16))
-                        elif t_arg[0].lower() == "color":
-                            t_dict["colour"] = Colour(int(t_arg[1], 16))
-                        elif t_arg[0].lower() == "hoist":
-                            t_dict["hoist"] = is_positive(t_arg[1])
-                        elif t_arg[0].lower() == "mentionable":
-                            t_dict["mentionable"] = is_positive(t_arg[1])
-                        elif t_arg[0].lower() == "position":
-                            if t_arg[1].isdecimal():
-                                pos = int(t_arg[1])
-                                if pos > 0:
-                                    rolepos = pos
-                            else:
-                                raise CommandSyntaxError("Position must be a positive integer.")
+                try:
+                    t_dict = {
+                        "name": p_args['name'] if p_args['name'] else args[1],
+                        "permissions": role.permissions,
+                        "colour": Colour(int(p_args['colour'], 16)) if p_args['colour'] else role.colour,
+                        "hoist": is_positive(p_args['hoist']) if p_args['hoist'] else role.hoist,
+                        "mentionable": is_positive(p_args['mentionable']) if p_args['mentionable'] else role.mentionable
+                    }
+                except ValueError:
+                    raise CommandSyntaxError("Colour must be in web-colour hexadecimal format.")
+
+                rolepos = max(0, p_args['position']) if p_args['position'] else role.position
+
                 t_role = await msg.guild.create_role(**t_dict)
+
                 try:
                     # since I can't create a role with a preset position :T
                     await t_role.edit(position=rolepos)
@@ -126,8 +133,7 @@ class RoleCommands(BasePlugin):
                     # oh hey, why are we copying this role again?
                     name = args[1].capitalize()
                     await t_role.delete()
-                    await respond(msg, f"**WARNING: Failed to move role {name} to position {rolepos}.**")
-                    raise Forbidden  # yeah, we're not copying this
+                    raise CommandSyntaxError(f"Failed to move role {name} to position {rolepos}.")
                 t_string = ""
                 for k, v in t_dict.items():
                     if k != "permissions":

--- a/rs_utils.py
+++ b/rs_utils.py
@@ -105,17 +105,6 @@ class RSArgumentParser(argparse.ArgumentParser):
         raise CommandSyntaxError(message)
 
     def error(self, message):
-        """error(message: string)
-
-        Prints a usage message incorporating the message to stderr and
-        exits.
-
-        If you override this in a subclass, it should not return -- it
-        should either exit or raise an exception.
-        """
-        # self.print_usage(_sys.stderr)
-        # args = {'prog': self.prog, 'message': message}
-        # self.exit(2, _('%(prog)s: error: %(message)s\n') % args)
         raise CommandSyntaxError(message)
 
     def parse_args(self, args=None, namespace=None):

--- a/rs_utils.py
+++ b/rs_utils.py
@@ -6,6 +6,7 @@ import shelve
 import json
 from io import BytesIO
 from pickle import Pickler, Unpickler
+from rs_errors import CommandSyntaxError
 
 
 class DotDict(dict):
@@ -350,6 +351,7 @@ def is_positive(string):
     elif string.lower() in ["on", "enable", "yes", "affirmative", "true"]:
         return True
     else:
-        raise SyntaxError("Expected positive/negative input.")
+        raise CommandSyntaxError("Expected positive/negative input. Allowed inputs: off/disable/no/negative/false, "
+                                 "on/enable/yes/affirmatie/true.")
 
 

--- a/rs_utils.py
+++ b/rs_utils.py
@@ -7,6 +7,7 @@ import json
 from io import BytesIO
 from pickle import Pickler, Unpickler
 from rs_errors import CommandSyntaxError
+import argparse
 
 
 class DotDict(dict):
@@ -81,6 +82,324 @@ class Cupboard(shelve.Shelf):
                 self.dict = shelve._ClosedDict()
             except Exception:
                 self.dict = None
+
+
+class RSNamespace(argparse.Namespace):
+    def __getitem__(self, key):
+        try:
+            return self.__getattribute__(key)
+        except AttributeError:
+            raise KeyError
+
+    def __setitem__(self, key, value):
+        self.__setattr__(key, value)
+
+
+class RSArgumentParser(argparse.ArgumentParser):
+
+    def __init__(self, add_help=False, ignore_unrecognized_arguments=True, **kwargs):
+        self.ignore_unrecognized_arguments = ignore_unrecognized_arguments
+        super().__init__(self, add_help=add_help, **kwargs)
+
+    def exit(self, status=0, message=None):
+        raise CommandSyntaxError(message)
+
+    def error(self, message):
+        """error(message: string)
+
+        Prints a usage message incorporating the message to stderr and
+        exits.
+
+        If you override this in a subclass, it should not return -- it
+        should either exit or raise an exception.
+        """
+        # self.print_usage(_sys.stderr)
+        # args = {'prog': self.prog, 'message': message}
+        # self.exit(2, _('%(prog)s: error: %(message)s\n') % args)
+        raise CommandSyntaxError(message)
+
+    def parse_args(self, args=None, namespace=None):
+        args, argv = self.parse_known_args(args, namespace)
+        if argv and not self.ignore_unrecognized_arguments:
+            msg = 'Unrecognized arguments: %s'
+            self.error(msg % ' '.join(argv))
+        return args
+
+    def parse_known_args(self, args=None, namespace=None):
+        if args is None:
+            raise CommandSyntaxError("No arguments. How did you even manage that.")
+        else:
+            # make sure that args are mutable
+            args = list(args)
+
+        # default Namespace built from parser defaults
+        if namespace is None:
+            namespace = RSNamespace()
+
+        # add any action defaults that aren't present
+        for action in self._actions:
+            if action.dest is not argparse.SUPPRESS:
+                if not hasattr(namespace, action.dest):
+                    if action.default is not argparse.SUPPRESS:
+                        setattr(namespace, action.dest, action.default)
+
+        # add any parser defaults that aren't present
+        for dest in self._defaults:
+            if not hasattr(namespace, dest):
+                setattr(namespace, dest, self._defaults[dest])
+
+        # parse the arguments and exit if there are any errors
+        try:
+            namespace, args = self._parse_known_args(args, namespace)
+            if hasattr(namespace, argparse._UNRECOGNIZED_ARGS_ATTR):
+                args.extend(getattr(namespace, argparse._UNRECOGNIZED_ARGS_ATTR))
+                delattr(namespace, argparse._UNRECOGNIZED_ARGS_ATTR)
+            return namespace, args
+        except argparse.ArgumentError:
+            err = argparse._sys.exc_info()[1]
+            self.error(str(err))
+
+    def _parse_known_args(self, arg_strings, namespace):
+        # replace arg strings that are file references
+        if self.fromfile_prefix_chars is not None:
+            arg_strings = self._read_args_from_files(arg_strings)
+
+        # map all mutually exclusive arguments to the other arguments
+        # they can't occur with
+        action_conflicts = {}
+        for mutex_group in self._mutually_exclusive_groups:
+            group_actions = mutex_group._group_actions
+            for i, mutex_action in enumerate(mutex_group._group_actions):
+                conflicts = action_conflicts.setdefault(mutex_action, [])
+                conflicts.extend(group_actions[:i])
+                conflicts.extend(group_actions[i + 1:])
+
+        # find all option indices, and determine the arg_string_pattern
+        # which has an 'O' if there is an option at an index,
+        # an 'A' if there is an argument, or a '-' if there is a '--'
+        option_string_indices = {}
+        arg_string_pattern_parts = []
+        arg_strings_iter = iter(arg_strings)
+        for i, arg_string in enumerate(arg_strings_iter):
+
+            # all args after -- are non-options
+            if arg_string == '--':
+                arg_string_pattern_parts.append('-')
+                for arg_string in arg_strings_iter:
+                    arg_string_pattern_parts.append('A')
+
+            # otherwise, add the arg to the arg strings
+            # and note the index if it was an option
+            else:
+                option_tuple = self._parse_optional(arg_string)
+                if option_tuple is None:
+                    pattern = 'A'
+                else:
+                    option_string_indices[i] = option_tuple
+                    pattern = 'O'
+                arg_string_pattern_parts.append(pattern)
+
+        # join the pieces together to form the pattern
+        arg_strings_pattern = ''.join(arg_string_pattern_parts)
+
+        # converts arg strings to the appropriate and then takes the action
+        seen_actions = set()
+        seen_non_default_actions = set()
+
+        def take_action(action, argument_strings, option_string=None):
+            seen_actions.add(action)
+            argument_values = self._get_values(action, argument_strings)
+
+            # error if this argument is not allowed with other previously
+            # seen arguments, assuming that actions that use the default
+            # value don't really count as "present"
+            if argument_values is not action.default:
+                seen_non_default_actions.add(action)
+                for conflict_action in action_conflicts.get(action, []):
+                    if conflict_action in seen_non_default_actions:
+                        msg = 'not allowed with argument %s'
+                        action_name = argparse._get_action_name(conflict_action)
+                        raise argparse.ArgumentError(action, msg % action_name)
+
+            # take the action if we didn't receive a SUPPRESS value
+            # (e.g. from a default)
+            if argument_values is not argparse.SUPPRESS:
+                action(self, namespace, argument_values, option_string)
+
+        # function to convert arg_strings into an optional action
+        def consume_optional(start_index):
+
+            # get the optional identified at this index
+            option_tuple = option_string_indices[start_index]
+            action, option_string, explicit_arg = option_tuple
+
+            # identify additional optionals in the same arg string
+            # (e.g. -xyz is the same as -x -y -z if no args are required)
+            match_argument = self._match_argument
+            action_tuples = []
+            while True:
+
+                # if we found no optional action, skip it
+                if action is None:
+                    extras.append(arg_strings[start_index])
+                    return start_index + 1
+
+                # if there is an explicit argument, try to match the
+                # optional's string arguments to only this
+                if explicit_arg is not None:
+                    arg_count = match_argument(action, 'A')
+
+                    # if the action is a single-dash option and takes no
+                    # arguments, try to parse more single-dash options out
+                    # of the tail of the option string
+                    chars = self.prefix_chars
+                    if arg_count == 0 and option_string[1] not in chars:
+                        action_tuples.append((action, [], option_string))
+                        char = option_string[0]
+                        option_string = char + explicit_arg[0]
+                        new_explicit_arg = explicit_arg[1:] or None
+                        optionals_map = self._option_string_actions
+                        if option_string in optionals_map:
+                            action = optionals_map[option_string]
+                            explicit_arg = new_explicit_arg
+                        else:
+                            raise argparse.ArgumentError(action, 'ignored explicit argument %r' % explicit_arg)
+
+                    # if the action expect exactly one argument, we've
+                    # successfully matched the option; exit the loop
+                    elif arg_count == 1:
+                        stop = start_index + 1
+                        args = [explicit_arg]
+                        action_tuples.append((action, args, option_string))
+                        break
+
+                    # error if a double-dash option did not use the
+                    # explicit argument
+                    else:
+                        raise argparse.ArgumentError(action, 'ignored explicit argument %r' % explicit_arg)
+
+                # if there is no explicit argument, try to match the
+                # optional's string arguments with the following strings
+                # if successful, exit the loop
+                else:
+                    start = start_index + 1
+                    selected_patterns = arg_strings_pattern[start:]
+                    arg_count = match_argument(action, selected_patterns)
+                    stop = start + arg_count
+                    args = arg_strings[start:stop]
+                    action_tuples.append((action, args, option_string))
+                    break
+
+            # add the Optional to the list and return the index at which
+            # the Optional's string args stopped
+            assert action_tuples
+            for action, args, option_string in action_tuples:
+                take_action(action, args, option_string)
+            return stop
+
+        # the list of Positionals left to be parsed; this is modified
+        # by consume_positionals()
+        positionals = self._get_positional_actions()
+
+        # function to convert arg_strings into positional actions
+        def consume_positionals(start_index):
+            # match as many Positionals as possible
+            match_partial = self._match_arguments_partial
+            selected_pattern = arg_strings_pattern[start_index:]
+            arg_counts = match_partial(positionals, selected_pattern)
+
+            # slice off the appropriate arg strings for each Positional
+            # and add the Positional and its args to the list
+            for action, arg_count in zip(positionals, arg_counts):
+                args = arg_strings[start_index: start_index + arg_count]
+                start_index += arg_count
+                take_action(action, args)
+
+            # slice off the Positionals that we just parsed and return the
+            # index at which the Positionals' string args stopped
+            positionals[:] = positionals[len(arg_counts):]
+            return start_index
+
+        # consume Positionals and Optionals alternately, until we have
+        # passed the last option string
+        extras = []
+        start_index = 0
+        if option_string_indices:
+            max_option_string_index = max(option_string_indices)
+        else:
+            max_option_string_index = -1
+        while start_index <= max_option_string_index:
+
+            # consume any Positionals preceding the next option
+            next_option_string_index = min([
+                index
+                for index in option_string_indices
+                if index >= start_index])
+            if start_index != next_option_string_index:
+                positionals_end_index = consume_positionals(start_index)
+
+                # only try to parse the next optional if we didn't consume
+                # the option string during the positionals parsing
+                if positionals_end_index > start_index:
+                    start_index = positionals_end_index
+                    continue
+                else:
+                    start_index = positionals_end_index
+
+            # if we consumed all the positionals we could and we're not
+            # at the index of an option string, there were extra arguments
+            if start_index not in option_string_indices:
+                strings = arg_strings[start_index:next_option_string_index]
+                extras.extend(strings)
+                start_index = next_option_string_index
+
+            # consume the next optional and any arguments for it
+            start_index = consume_optional(start_index)
+
+        # consume any positionals following the last Optional
+        stop_index = consume_positionals(start_index)
+
+        # if we didn't consume all the argument strings, there were extras
+        extras.extend(arg_strings[stop_index:])
+
+        # make sure all required actions were present and also convert
+        # action defaults which were not given as arguments
+        required_actions = []
+        for action in self._actions:
+            if action not in seen_actions:
+                if action.required:
+                    required_actions.append(argparse._get_action_name(action))
+                else:
+                    # Convert action default now instead of doing it before
+                    # parsing arguments to avoid calling convert functions
+                    # twice (which may fail) if the argument was given, but
+                    # only if it was defined already in the namespace
+                    if (action.default is not None and
+                        isinstance(action.default, str) and
+                        hasattr(namespace, action.dest) and
+                        action.default is getattr(namespace, action.dest)):
+                        setattr(namespace, action.dest,
+                                self._get_value(action, action.default))
+
+        if required_actions:
+            self.error('Missing arguments: %s.' % ', '.join(required_actions))
+
+        # make sure all required groups had one option present
+        for group in self._mutually_exclusive_groups:
+            if group.required:
+                for action in group._group_actions:
+                    if action in seen_non_default_actions:
+                        break
+
+                # if no actions were used, report the error
+                else:
+                    names = [argparse._get_action_name(action)
+                             for action in group._group_actions
+                             if action.help is not argparse.SUPPRESS]
+                    self.error('one of the arguments %s is required' % ' '.join(names))
+
+        # return the updated namespace and the extra arguments
+        return namespace, extras
 
 
 def dict_merge(d, u):
@@ -353,5 +672,3 @@ def is_positive(string):
     else:
         raise CommandSyntaxError("Expected positive/negative input. Allowed inputs: off/disable/no/negative/false, "
                                  "on/enable/yes/affirmatie/true.")
-
-


### PR DESCRIPTION
Implemented following classes:

- RSNamespace: implementation of argparse.Namespace that allows dict-like access to it's contents.
- RSArgumentParser: implementation argparse.ArgumentParser that uses Red Star errors and allows to ignore unrecognized arguments.

Changed usage of following commands:

- !EditRole ROLE 
  - --name - New role name
  - --colour - New role colour
  - --hoist - Show role separately from others. Uses is_positive()
  - --mentionable - Allow the role to be mentioned. Uses is_positive()
  - --position - Moves the role. Not recommended to use. 
- !CreateRole ROLE TEMPLATE
  - --name - New role name
  - --colour - New role colour
  - --hoist - Show role separately from others. Uses is_positive()
  - --mentionable - Allow the role to be mentioned. Uses is_positive()
  - --position - Moves the role. Not recommended to use. 
- !Purge COUNT
  - MATCH - Optional. Mind the shlex formatting. Accumulates all extra positional arguments.
  - --regex - Treat the match as a regexp.
  - --user - Purge messages of a specific user by name, mention or ID.
  - --verbose - Dumps the contents of deleted messages into the log, to be extra sure.
  - --emulate - Dry run to check your query result. Useful for testing or making sure your regex is right.
